### PR TITLE
Fix next.config.js: Add missing module.exports statement

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,3 +8,5 @@ const nextConfig = {
     formats: ['image/webp', 'image/avif'],
   },
 }
+
+module.exports = nextConfig


### PR DESCRIPTION
## Summary
- Fixed the missing `module.exports` statement in next.config.js that was causing Netlify builds to fail

## Test plan
- [x] Verify next.config.js exports the configuration correctly
- [ ] Netlify build should succeed with this fix

🤖 Generated with [Claude Code](https://claude.ai/code)