### PR TITLE
Fix Netlify 404 deployment error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,21 @@
+[build]
+  command = "npm run build"
+  publish = ".next"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"
+
+[build.environment]
+  NEXT_USE_NETLIFY_EDGE = "true"
+
+[[redirects]]
+  from = "/"
+  to = "/fr"
+  status = 302
+  conditions = {Language = ["fr"]}
+
+[[redirects]]
+  from = "/"
+  to = "/en"
+  status = 302
+  conditions = {Language = ["en"]}


### PR DESCRIPTION
## Summary
- Added netlify.toml configuration file to properly deploy Next.js app with i18n support
- Configured @netlify/plugin-nextjs to handle server-side rendering
- Added language-based redirects for French and English locales

## Problem
The site was showing a 404 error because Next.js apps with i18n routing require special configuration on Netlify. The default static export doesn't work with internationalization.

## Solution
Using Netlify's official Next.js plugin which supports:
- Server-side rendering
- Internationalization routing
- Dynamic routes

## Test plan
- [ ] Deploy to Netlify
- [ ] Verify homepage loads without 404 error
- [ ] Test language switching works correctly
- [ ] Ensure all pages render properly

🤖 Generated with [Claude Code](https://claude.ai/code)